### PR TITLE
Add "show subscription details" method

### DIFF
--- a/lib/resources/Subscription.js
+++ b/lib/resources/Subscription.js
@@ -67,18 +67,6 @@ function subscription() {
         },
 
         /**
-         * Cancels subscription
-         * @param  {String}   id     Identifier of the subscription to cancel
-         * @param  {Object}   reason   Add note, the reason for changing state of subscription, 1-128 characters
-         * @param  {Object}   config     Configuration parameters e.g. client_id, client_secret override
-         * @return {}          Returns the HTTP status of 204 if the call is successful
-         */
-         cancel: async function cancel(id, reason, config) {
-            let data = reason ? { reason: reason } : null;
-            return await api.executeAsync('POST', this.baseURL + id + '/cancel', data, config);
-        },
-
-        /**
          * Changes subscription state to suspended, can be reactivated unlike cancelling subscription
          * @param  {String}   id     Identifier of the subscription for which to suspend
          * @param  {Object}   reason   Add note, the reason for changing state of subscription

--- a/lib/resources/Subscription.js
+++ b/lib/resources/Subscription.js
@@ -67,6 +67,18 @@ function subscription() {
         },
 
         /**
+         * Cancels subscription
+         * @param  {String}   id     Identifier of the subscription to cancel
+         * @param  {Object}   reason   Add note, the reason for changing state of subscription, 1-128 characters
+         * @param  {Object}   config     Configuration parameters e.g. client_id, client_secret override
+         * @return {}          Returns the HTTP status of 204 if the call is successful
+         */
+         cancel: async function cancel(id, reason, config) {
+            let data = reason ? { reason: reason } : null;
+            return await api.executeAsync('POST', this.baseURL + id + '/cancel', data, config);
+        },
+
+        /**
          * Changes subscription state to suspended, can be reactivated unlike cancelling subscription
          * @param  {String}   id     Identifier of the subscription for which to suspend
          * @param  {Object}   reason   Add note, the reason for changing state of subscription

--- a/lib/resources/Subscription.js
+++ b/lib/resources/Subscription.js
@@ -17,6 +17,16 @@ function subscription() {
         baseURL: baseURL,
 
         /**
+         * Show subscription details
+         * @param  {String}   id         Identifier of the subscription for which to show details.
+         * @param  {Object}   config     Configuration parameters e.g. client_id, client_secret override
+         * @return {Object}              subscription object
+         */
+         show: async function show(id, config) {
+            return await api.executeAsync('GET', baseURL + id, config);
+        },
+
+        /**
          * Charge money to subscriber. Executes the actual payment for the current cycle.
          *
          * Subscription must be already in status approved or active.

--- a/lib/resources/Subscription.js
+++ b/lib/resources/Subscription.js
@@ -23,7 +23,7 @@ function subscription() {
          * @return {Object}              subscription object
          */
          show: async function show(id, config) {
-            return await api.executeAsync('GET', baseURL + id, config);
+            return await api.executeAsync('GET', baseURL + id, {}, config);
         },
 
         /**


### PR DESCRIPTION
Add "show subscription details" method (`paypal.subscription.show`) as per https://developer.paypal.com/docs/subscriptions/full-integration/subscription-management/#show-subscription-details

Note: not sure about `.show` as the verb, was tempted to go with `.get`, but `.show` seemed like a more conservative choice, as it hews closely to the language used in the PayPal docs.